### PR TITLE
update filter_group for report file

### DIFF
--- a/cidc_ngs_pipeline_api/__init__.py
+++ b/cidc_ngs_pipeline_api/__init__.py
@@ -6,7 +6,7 @@ from json import load
 
 __author__ = """Stephen C van Nostrand"""
 __email__ = "vannost@ds.dfci.harvard.edu"
-__version__ = "0.1.15"
+__version__ = "0.1.14"
 
 
 _API_ENDING = "_output_API.json"

--- a/cidc_ngs_pipeline_api/__init__.py
+++ b/cidc_ngs_pipeline_api/__init__.py
@@ -6,7 +6,7 @@ from json import load
 
 __author__ = """Stephen C van Nostrand"""
 __email__ = "vannost@ds.dfci.harvard.edu"
-__version__ = "0.1.14"
+__version__ = "0.1.15"
 
 
 _API_ENDING = "_output_API.json"

--- a/cidc_ngs_pipeline_api/atacseq/atacseq_output_API.json
+++ b/cidc_ngs_pipeline_api/atacseq/atacseq_output_API.json
@@ -29,7 +29,7 @@
             "file_purpose": "Analysis view"
         },
         {
-            "filter_group": "report/report.zip",
+            "filter_group": "report",
             "file_path_template": "analysis/report/report.zip",
             "short_description": "summary report",
             "long_description": "A html report with five sections: Overview, Read Level Summary, Peak Level Summary, Genome Track View, and Downstream",


### PR DESCRIPTION
## What

This PR fixes the `filter_group` for the report.zip file in ATACseq analysis, to comply with the corresponding facet group defined in [cidc-api-gae#facets for ATACseq](https://github.com/CIMAC-CIDC/cidc-api-gae/blob/atacseq/cidc_api/models/files/facets.py#L81).

## Why

We don't encode file extensions or full file names in the filter_group.

## Remarks

NA

## Mentions

@scvannost 

## Checklist

Please include and complete the following checklist. Your Pull Request is (in most cases) not ready for review until the following have been completed. You can create a draft PR while you are still completing the checklist. You can mark an item as complete with the `- [x]` prefix

- [x] Formatting & Linting - `black` and `flake8` have been used to ensure styling guidelines are met
- [ ] Type Annotations - New code has been type annotated in the function signatures using type hints
- [ ] Documentation - Short and long descriptions of files which have been updated in the schema. Docstrings have been provided for functions
- [ ] Tests - Added unit tests for new code
- [x] Package version - Manually bumped the package version in [cidc_ngs_pipeline_api/__init__.py](https://github.com/CIMAC-CIDC/cidc-ngs-pipeline-api/blob/master/cidc_ngs_pipeline_api/__init__.py#L9)
