### PR TITLE
Removing cohort-report from atacseq_output_API.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,13 @@ This Changelog tracks changes to this project. The notes below include a summary
 - `fixed` for any bug fixes.
 - `security` in case of vulnerabilities.
 
+## Version `0.1.23` - 20 Dec 2022
+
+- `removed` ATACseq batch-level report
 
 ## 31 Oct 2022
 
-- `changed` updated structure in README
+- `changed` updated ATACseq structure in README
 
 ## Version `0.1.22` - 31 Aug 2022
 

--- a/cidc_ngs_pipeline_api/__init__.py
+++ b/cidc_ngs_pipeline_api/__init__.py
@@ -6,7 +6,7 @@ from json import load
 
 __author__ = """Stephen C van Nostrand"""
 __email__ = "vannost@ds.dfci.harvard.edu"
-__version__ = "0.1.22"
+__version__ = "0.1.23"
 
 
 _API_ENDING = "_output_API.json"

--- a/cidc_ngs_pipeline_api/atacseq/atacseq_output_API.json
+++ b/cidc_ngs_pipeline_api/atacseq/atacseq_output_API.json
@@ -35,14 +35,5 @@
             "long_description": "bwa-mem aligned sorted alignment file",
             "file_purpose": "Source view"
         }
-    ],
-    "batch id": [
-        {
-            "filter_group": "report",
-            "file_path_template": "analysis/{batch id}/report.zip",
-            "short_description": "summary report",
-            "long_description": "A html report with five sections: Overview, Read Level Summary, Peak Level Summary, Genome Track View, and Downstream",
-            "file_purpose": "Analysis view"
-        }
     ]
 }


### PR DESCRIPTION
## What

This PR Removes the cohort report from the CHIPS ingestion API

## Why

The cohort report is hard to generate and it is not used.

## Remarks

The  ATACseq ingestion template should be updated to reflect this change.

## Mentions

@scvannost @jen-dfci 

## Checklist

Please include and complete the following checklist. Your Pull Request is (in most cases) not ready for review until the following have been completed. You can create a draft PR while you are still completing the checklist. You can mark an item as complete with the `- [x]` prefix

- [x] Formatting & Linting - `black` and `flake8` have been used to ensure styling guidelines are met
- [x] Type Annotations - New code has been type annotated in the function signatures using type hints
- [x] Documentation - Short and long descriptions of files which have been updated in the schema. Docstrings have been provided for functions
- [x] Tests - Added unit tests for new code
- [x] Package version - Manually bumped the package version in [cidc_ngs_pipeline_api/__init__.py](https://github.com/CIMAC-CIDC/cidc-ngs-pipeline-api/blob/master/cidc_ngs_pipeline_api/__init__.py#L9)
